### PR TITLE
fix(playground): use media query based dark mode

### DIFF
--- a/playground/src/components/UBasePage.vue
+++ b/playground/src/components/UBasePage.vue
@@ -1,9 +1,5 @@
-<script setup lang='ts'>
-const { darkMode } = storeToRefs(useAppStore())
-</script>
-
 <template>
-  <APage class="font-sans" :dark="darkMode">
+  <APage class="font-sans">
     <slot />
   </APage>
 </template>

--- a/playground/src/manifest.json
+++ b/playground/src/manifest.json
@@ -14,14 +14,17 @@
       "postcss": true
     },
     "usingComponents": true,
-    "darkmode": true,
-    "themeLocation": "theme.json"
+    "darkmode": true
   },
   "uniStatistics": {
     "enable": false
   },
+  "h5": {
+    "darkmode": true
+  },
   "vueVersion": "3",
   "app-plus": {
+    "darkmode": true,
     "distribute": {
       "ios": {
         "dSYMs": false

--- a/playground/unocss.config.ts
+++ b/playground/unocss.config.ts
@@ -17,17 +17,16 @@ import {
 import { presetAno } from '../packages/ano-ui/src/preset'
 
 const isApplet = process.env?.UNI_PLATFORM?.startsWith('mp') ?? false
-const presets: Preset[] = []
+const presets: Preset[] = [presetApplet({ dark: 'media' })]
+
 const transformers: SourceCodeTransformer[] = []
 
 if (isApplet) {
-  presets.push(presetApplet())
   presets.push(presetRemRpx())
   transformers.push(transformerAttributify({ ignoreAttributes: ['block'] }))
   transformers.push(transformerApplet())
 }
 else {
-  presets.push(presetApplet())
   presets.push(presetAttributify())
   presets.push(presetRemRpx({ mode: 'rpx2rem' }))
 }
@@ -50,6 +49,9 @@ export default defineConfig({
     transformerVariantGroup(),
     ...transformers,
   ],
+  theme: {
+    preflightRoot: isApplet ? ['page,::before,::after'] : undefined,
+  },
   rules: [
     [
       'p-safe',


### PR DESCRIPTION
直接用 基于 media query 的 darkmode 不香吗，我在生产用的美滋滋

现在基于 class 的 darkmode 的好处是可以随时切换，但是改变不了 navbar 等等之类的系统组件（没啥大用除非全部用自定义组件