### PR TITLE
chore: fix build and dev error

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   "scripts": {
     "dev": "pnpm stub",
     "build": "rimraf dist & esno build/components.ts & unbuild",
-    "stub": "unbuild stub",
+    "stub": "unbuild --stub",
     "release": "bumpp package.json ./src/ano-ui/*/package.json",
     "dev:app": "uni -p app",
     "dev:custom": "uni -p",

--- a/src/ano-ui/components/ANotify/notify.ts
+++ b/src/ano-ui/components/ANotify/notify.ts
@@ -40,7 +40,3 @@ export const notifyEmits = {
 
 export type NotifyProps = ExtractPropTypes<typeof notifyProps>
 export type NotifyEmits = typeof notifyEmits
-export interface NotifyInst {
-  show: (options?: NotifyOptions) => {}
-  close: () => {}
-}


### PR DESCRIPTION
dev script 少加了  `--`

```diff
-"dev": "unbuild stub",
+"dev": "unbuild --stub",
```

build 的话, notify 导出了多个 `NotifyInst`

```
src/ano-ui/components/ANotify/index.ts(3,1): error TS2308: Module './notify' has already exported a member named 'NotifyInst'. Consider explicitly re-exporting to resolve the ambiguity.
```